### PR TITLE
Filters

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -82,7 +82,15 @@ fn bound_val<'v: 'b, 'b>(val: &'v Term<Value>, binding: &'b Binding) -> Option<&
 
 impl Constraint {
     pub fn check(&self, binding: &Binding) -> bool {
-        match (
+        println!("Binding: {:?}", binding);
+        println!(
+            "Check: {:?} {:?} {:?}",
+            self.first_value,
+            self.comperator,
+            self.second_value
+        );
+
+        let res = match (
             self.comperator,
             bound_val(&self.first_value, binding),
             bound_val(&self.second_value, binding),
@@ -92,6 +100,10 @@ impl Constraint {
             (Comperator::GreaterThan, Some(fst_val), Some(snd_val)) => fst_val > snd_val,
             (Comperator::LesserThan, Some(fst_val), Some(snd_val)) => fst_val < snd_val,
             (Comperator::NotEqualTo, Some(fst_val), Some(snd_val)) => fst_val != snd_val,
-        }
+        };
+
+        println!("Res: {:?}", res);
+
+        res
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,13 +5,15 @@ use {Entity, Value};
 pub struct Query {
     pub find: Vec<Var>,
     pub clauses: Vec<Clause>,
+    pub constraints: Vec<Constraint>,
 }
 
 impl Query {
-    pub fn new(find: Vec<Var>, clauses: Vec<Clause>) -> Query {
+    pub fn new(find: Vec<Var>, clauses: Vec<Clause>, constraints: Vec<Constraint>) -> Query {
         Query {
             find: find,
             clauses: clauses,
+            constraints: constraints,
         }
     }
 }
@@ -55,4 +57,18 @@ impl<T: Into<String>> From<T> for Var {
     fn from(x: T) -> Self {
         Var { name: x.into() }
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Comperator {
+    GreaterThan,
+    LesserThan,
+    NotEqualTo,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Constraint {
+    pub comperator: Comperator,
+    pub first_value: Term<Value>,
+    pub second_value: Term<Value>,
 }


### PR DESCRIPTION
This adds filters to the query language.

There are only three comperators available at this moment (`>`, `<` and `not`), but this set should be easy to extend. The syntax is very straightforward: a constraint it is basically a clause starting with the comparator and followed by two potentially unbound values. Only bindings which satisfy the constraints are included in the query result.

Incidentally, this should enable us to query the database at some earlier time, by setting an upper limit on the transaction timestamp. I'm just not sure if it's possible to pass timestamp literals to logos yet..

Closes https://github.com/loganmhb/logos/issues/21.
Closes https://github.com/loganmhb/logos/issues/20.